### PR TITLE
Move commit msg variable to lower case

### DIFF
--- a/webhooks/github_feature_tracker.cgi
+++ b/webhooks/github_feature_tracker.cgi
@@ -420,7 +420,7 @@ try:
         issues_url = 'https://api.github.com/repos/%s/issues' % ISSUES_REPO
         for commit in data['commits']:
             msg = commit['message']
-            if '[FEATURE]' in msg:
+            if '[FEATURE]' in msg.upper():
                 # message is both title and description from the commit, separated by \n\n
                 msg = msg.split('\n\n')
                 title = msg[0]


### PR DESCRIPTION
[FEATURE] trigger the script but some dev could write it in lower case
or a mix.

Fix: https://github.com/qgis/QGIS-Documentation/issues/826