### PR TITLE
Ansible: support sending emails to multiple addresses

### DIFF
--- a/qgis4/ansible/roles/certifsuite/tasks/main.yml
+++ b/qgis4/ansible/roles/certifsuite/tasks/main.yml
@@ -16,7 +16,7 @@
     recurse: True
 
 - name: Copy ci script
-  copy:
+  template:
     dest: "/home/{{ user }}/certifsuite-ci.sh"
     src: "certifsuite-ci.sh"
     owner: "{{ user }}"

--- a/qgis4/ansible/roles/certifsuite/templates/certifsuite-ci.sh
+++ b/qgis4/ansible/roles/certifsuite/templates/certifsuite-ci.sh
@@ -3,12 +3,14 @@ WMS130=/tmp/certifsuite-wms130
 WFS110=/tmp/certifsuite-wfs110
 DATE=$(date +"%Y_%m_%d_%H_%M")
 
-MAIL_ADRESS="blottiere.paul@gmail.com"
+MAIL_ADDRESSES="{{ mail_addresses|join(' ') }}"
 MAIL_SUBJECT=""
 MAIL_BODY=""
 
 sendmail(){
-  echo "$MAIL_BODY" | mail -s "$MAIL_SUBJECT" $MAIL_ADRESS
+  for mail_address in $MAIL_ADDRESSES; do
+      echo "$MAIL_BODY" | mail -s "$MAIL_SUBJECT" $mail_address
+  done
 }
 
 echo "Remove docker images for master"

--- a/qgis4/ansible/vars.yml
+++ b/qgis4/ansible/vars.yml
@@ -21,3 +21,7 @@ qwc2_hour: "6"
 qwc2_port: "8081"
 
 user: "qgis-server-admin"
+
+mail_addresses:
+- blottiere.paul@gmail.com
+- eric.lemoine@gmail.com


### PR DESCRIPTION
This makes `certifsuite-ci.sh` a template (rather than a file) and modifies its `sendfile` function to support sending emails to multiple addresses.