### PR TITLE
Use node setup_10.x instead of setup_9.x

### DIFF
--- a/qgis4/online/qwc2/Dockerfile
+++ b/qgis4/online/qwc2/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update \
     && apt-get install -y yarn nodejs
 


### PR DESCRIPTION
We currently have this error at "qwc2-demo-apps-build" image build time:

    ./qwc2/scripts/package-commands.sh: line 17: npm: command not found
    error Command failed with exit code 127.

With setup_10.x there's no need to explicitely install npm, as it's
provided by the nodejs package.